### PR TITLE
Add notification about copyrights and publicity

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -74,7 +74,10 @@
       </div>
     </div>
     <div class="row">
-      <div class="span12 well"><a href="https://redmine.tietokilta.fi/projects/tenttiarkisto/issues/">Bug reports & feature requests</a></div>
+      <div class="span12 well">
+        <p><a href="https://redmine.tietokilta.fi/projects/tenttiarkisto/issues/">Bug reports & feature requests</a></p>
+        <p>Would you like to have your exam removed from this page? Please read (in Finnish) <a href="http://www.uta.fi/opiskelu/tietosuoja/sanasto.html#koekysymykset">this</a> and <a href="http://www.opettajantekijanoikeus.fi/2012/01/tehtavasarjat-eivat-valttamatta-ole-tekijanoikeuden-suojaamia/">this</a>, then consider again.</p>
+        </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
There should be some kind of notification that we don't remove exams from tenttiarkisto. So this adds links to resources which basically say that exams are public and we can publish them without permission.

This might not be the most beautiful way to do it, but at least it works.
