### PR TITLE
fix(dockerfile): bump gunicorn worker timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /opt/tenttiarkisto
 RUN venv/bin/python manage.py collectstatic
 # only set this after collectstatic, so it can copy files over without complaining about env vars
 ENV DJANGO_SETTINGS_MODULE=tenttiarkisto.settings.production
-CMD ["venv/bin/python", "-m", "gunicorn", "--bind=0.0.0.0:8000", "tenttiarkisto.wsgi"]
+CMD ["venv/bin/python", "-m", "gunicorn", "--bind=0.0.0.0:8000", "--timeout", "600", "tenttiarkisto.wsgi"]


### PR DESCRIPTION
This is done in accordance to Azure official documentation adviced by this stackoverflow thread: https://stackoverflow.com/questions/10855197/gunicorn-how-to-resolve-worker-timeout